### PR TITLE
fix: format grades in parse step

### DIFF
--- a/apps/core/queue/Actions/Batch/GetGradesBatch.php
+++ b/apps/core/queue/Actions/Batch/GetGradesBatch.php
@@ -56,7 +56,12 @@ final class GetGradesBatch
                     $gradeitem['percentageformatted'] = str_replace([' ', '%'], '', $gradeitem['percentageformatted']);
                     $grade = is_numeric($gradeitem['percentageformatted'])
                         ? (int) $gradeitem['percentageformatted']
-                        : null;
+                        : null
+                    ;
+
+                    if (isset($gradeitem['graderaw'])) {
+                        $gradeitem['graderaw'] = round((float) $gradeitem['graderaw'], 3);
+                    }
 
                     $grades[] = (new Grade(
                         grade_id: $gradeitem['id'],


### PR DESCRIPTION
# What's new

Now, graderaw formats in parse step, to avoid possible bugs around graderaw and fix existing. 

# Verification

Need to firstly check in stg(optional)
