### PR TITLE
Added cookies support instead of WebServices token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ node_modules
 
 .env
 *.local
-
+data/
 *.log

--- a/.justfile
+++ b/.justfile
@@ -1,0 +1,8 @@
+set shell := ["bash", "-lc"]
+
+up-local:
+	docker compose -f docker-compose-local.yml up --build -d
+
+remove-restart:
+    docker compose -f docker-compose-local.yml down -v
+    docker compose -f docker-compose-local.yml up --build -d

--- a/.justfile
+++ b/.justfile
@@ -1,8 +1,8 @@
 set shell := ["bash", "-lc"]
 
 up-local:
-	docker compose -f docker-compose-local.yml up --build -d
+    docker compose -f docker-compose-local.yml up --build -d
 
 remove-restart:
-    docker compose -f docker-compose-local.yml down -v
+    docker compose -f docker-compose-local.yml down -v || true
     docker compose -f docker-compose-local.yml up --build -d

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -9,7 +9,7 @@ export const env = cleanEnv(process.env, {
 
   TELEGRAM_BOT_TOKEN: str(),
 
-  MOODLE_URL: str({ default: "" }),
+  MOODLE_URL: str({ default: "https://lms.astanait.edu.kz" }),
 
   MONGO_URI: str({ default: "mongodb://localhost:27017/remoodle-dev" }),
   REDIS_URI: str({ default: "redis://localhost:6379" }),

--- a/apps/backend/src/core/queues.ts
+++ b/apps/backend/src/core/queues.ts
@@ -4,6 +4,9 @@ import { db } from "../library/db";
 import { bullOtel } from "./telemetry";
 
 export enum JobName {
+  COOKIES_SCHEDULE_SYNC = "cookies::schedule-sync",
+  COOKIES_UPDATE = "cookies::update",
+
   COURSES_SCHEDULE_SYNC = "courses::schedule-sync",
   COURSES_UPDATE = "courses::update",
 
@@ -20,6 +23,9 @@ export enum JobName {
 }
 
 export enum QueueName {
+  COOKIES_SYNC = "cookies sync",
+  COOKIES = "cookies update",
+
   EVENTS_SYNC = "events sync",
   EVENTS = "events update",
 

--- a/apps/backend/src/core/sync.ts
+++ b/apps/backend/src/core/sync.ts
@@ -1,7 +1,7 @@
 import type {
   IUser,
   MoodleCourse,
-  MoodleCourseClassification,
+  MoodleCourseClassification, MoodleGrade,
 } from "@remoodle/types";
 import { Moodle } from "../library/moodle";
 import { db, wrapper } from "../library/db";
@@ -216,35 +216,30 @@ export const syncCourseGrades = async (
     moodleSessionKey: user.moodleSessionKey,
   });
 
-  const [response, error] = await client.call(
-    "gradereport_user_get_grade_items",
-    {
-      userid: user.moodleId,
-      courseid: courseId,
-    },
-  );
+  let response: MoodleGrade[];
 
-  if (error) {
+  try {
+    response = await client.getGrades({ courseId });
+  } catch (error: any) {
     await handleTokenError(error, user);
     await handleCourseError(error, user, courseId);
     throw new Error(`Failed to get grades for ${courseId}: ${error.message}`);
   }
 
-  const normalizedGrades = response.usergrades[0].gradeitems.filter(
-    (grade) => grade.itemtype !== "course",
-  );
-
   const currentGrades = await db.grade.find({
     userId,
     courseId,
     "data.id": {
-      $in: normalizedGrades.map((grade) => grade.id),
+      $in: response.map((grade) => grade.id),
     },
   });
 
-  for (const grade of normalizedGrades) {
+  for (const grade of response) {
     await db.grade.findOneAndUpdate(
-      { userId, "data.id": grade.id },
+      {
+        userId,
+        "data.id": grade.id,
+      },
       {
         userId,
         courseId,
@@ -262,7 +257,7 @@ export const syncCourseGrades = async (
     userId,
     courseId,
     "data.id": {
-      $in: response.usergrades[0].gradeitems.map((grade) => grade.id),
+      $in: response.map((grade) => grade.id),
     },
   });
 

--- a/apps/backend/src/core/sync.ts
+++ b/apps/backend/src/core/sync.ts
@@ -39,7 +39,12 @@ export const syncEvents = async (userId: string) => {
     throw new Error("User not found");
   }
 
-  const client = new Moodle(user.moodleToken);
+  const client = new Moodle({
+    moodleUserId: user.moodleId,
+    moodleAuthCookies: user.moodleAuthCookies,
+    moodleSessionCookie: user.moodleSessionCookie,
+    moodleSessionKey: user.moodleSessionKey,
+  });
 
   const [response, error] = await client.call(
     "core_calendar_get_action_events_by_timesort",
@@ -89,7 +94,12 @@ export const syncCourses = async (
 
   const userMoodleId = user.moodleId;
 
-  const client = new Moodle(user.moodleToken);
+  const client = new Moodle({
+    moodleUserId: user.moodleId,
+    moodleAuthCookies: user.moodleAuthCookies,
+    moodleSessionCookie: user.moodleSessionCookie,
+    moodleSessionKey: user.moodleSessionKey,
+  });
 
   // Get existing courses before sync for change tracking
   const existingCourses = trackDiff
@@ -173,7 +183,12 @@ export const syncCourseGrades = async (
     throw new Error("User not found");
   }
 
-  const client = new Moodle(user.moodleToken);
+  const client = new Moodle({
+    moodleUserId: user.moodleId,
+    moodleAuthCookies: user.moodleAuthCookies,
+    moodleSessionCookie: user.moodleSessionCookie,
+    moodleSessionKey: user.moodleSessionKey,
+  });
 
   const [response, error] = await client.call(
     "gradereport_user_get_grade_items",

--- a/apps/backend/src/core/sync.ts
+++ b/apps/backend/src/core/sync.ts
@@ -6,12 +6,38 @@ import type {
 import { Moodle } from "../library/moodle";
 import { db, wrapper } from "../library/db";
 
+// TODO: rewrite handleTokenError to a more generic middleware-like function, that will be used in Moodle instance
 const handleTokenError = async (error: { message: string }, user: IUser) => {
   if (error.message.includes("Invalid token")) {
     await db.user.updateOne(
       { _id: user._id },
       { $set: { health: user.health - 1 } },
     );
+  }
+};
+
+export const syncCookies = async (userId: string) => {
+  console.log(`Syncing cookies for user ${userId}`);
+  const user = await db.user.findById(userId);
+
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  const client = new Moodle({
+    moodleUserId: user.moodleId,
+    moodleAuthCookies: user.moodleAuthCookies,
+    moodleSessionCookie: user.moodleSessionCookie,
+    moodleSessionKey: user.moodleSessionKey,
+  });
+
+  const [response, error] = await client.call("core_session_touch", {});
+
+  if (error) {
+    await handleTokenError(error, user);
+    throw new Error(`Failed to extend user moodle session: ${error.message}`);
+  } else if (!response) {
+    throw new Error("Failed to extend user moodle session: unsuccessful response");
   }
 };
 

--- a/apps/backend/src/core/sync.ts
+++ b/apps/backend/src/core/sync.ts
@@ -1,7 +1,8 @@
 import type {
   IUser,
   MoodleCourse,
-  MoodleCourseClassification, MoodleGrade,
+  MoodleCourseClassification,
+  MoodleGrade,
 } from "@remoodle/types";
 import { Moodle } from "../library/moodle";
 import { db, wrapper } from "../library/db";

--- a/apps/backend/src/library/moodle.ts
+++ b/apps/backend/src/library/moodle.ts
@@ -1,4 +1,5 @@
-import { MoodleClient } from "./moodleClient";  // TODO: remove, use "moodle-api" directly
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { MoodleClient, MoodleAPIError } from "./moodleClient";
 import type { FunctionDefinition } from "moodle-api";
 import { z } from "zod";
 import { config } from "../config";
@@ -6,9 +7,11 @@ import axios, { type AxiosInstance } from "axios";
 import { wrapper } from "axios-cookiejar-support";
 import { CookieJar } from "tough-cookie";
 import { load as loadHtml, type CheerioAPI } from "cheerio";
+import { db } from "./db";
 
 interface Options {
-  authCookies?: MoodleAuthCookie[];
+  moodleUserId?: number,
+  moodleAuthCookies?: MoodleAuthCookie[];
   moodleSessionCookie?: string;
   moodleSessionKey?: string;
 }
@@ -29,14 +32,16 @@ interface MoodleStudentInfo {
 }
 
 export class Moodle {
-  protected client?: MoodleClient;
-  protected authCookies?: MoodleAuthCookie[];
   protected httpClient?: AxiosInstance;
+  protected moodleClient?: MoodleClient;
+  protected moodleUserId?: number;
+  protected moodleAuthCookies?: MoodleAuthCookie[];
   protected moodleSessionCookie?: string;
   protected moodleSessionKey?: string;
 
   constructor(options: Options = {}) {
-    this.authCookies = options.authCookies;
+    this.moodleUserId = options.moodleUserId;
+    this.moodleAuthCookies = options.moodleAuthCookies;
     this.moodleSessionCookie = options.moodleSessionCookie;
     this.moodleSessionKey = options.moodleSessionKey;
   }
@@ -68,10 +73,6 @@ export class Moodle {
   }
 
   private async _getFormAndData(url: string) {
-    if (!this.authCookies) {
-      throw new Error("No auth cookies provided");
-    }
-
     const { httpClient } = this._createHttpSession();
 
     const respSrc = await httpClient.get(url);
@@ -82,7 +83,7 @@ export class Moodle {
     const redirectUrl = new URL(respSrc.headers.location, respSrc.config.url ?? url).toString();
     console.log(`Redirect from ${url} to ${redirectUrl}`);
 
-    httpClient.defaults.headers.Cookie = this.authCookies.map(c => `${encodeURIComponent(c.name)}=${encodeURIComponent(c.value)}`).join("; ");
+    httpClient.defaults.headers.Cookie = this.moodleAuthCookies!.map(c => `${encodeURIComponent(c.name)}=${encodeURIComponent(c.value)}`).join("; ");
 
     const resp = await httpClient.get(redirectUrl);
     console.log(`GET ${url} -> ${resp.status}: ${resp.data}`);
@@ -117,16 +118,14 @@ export class Moodle {
       const name = $(el).attr("name")!;
       const $options = $(el).find("option");
       const $selected = $options.filter("[selected]").first();
-      const value = $selected.length
+      moodlePostData[name] = $selected.length
         ? ($selected.attr("value") ?? "")
         : ($options.first().attr("value") ?? "");
-      moodlePostData[name] = value;
     });
 
     $form.find("textarea[name]").each((_: any, el: any) => {
       const name = $(el).attr("name")!;
-      const value = $(el).text() ?? "";
-      moodlePostData[name] = value;
+      moodlePostData[name] = $(el).text() ?? "";
     });
 
     return { httpClient, moodlePostUrl, moodlePostData };
@@ -162,6 +161,10 @@ export class Moodle {
   }
 
   async authByCookies() {
+    if (!this.moodleAuthCookies) {
+      throw new Error("No auth cookies provided");
+    }
+
     const { httpClient, moodlePostUrl, moodlePostData } = await this._getFormAndData(`${config.moodle.url}/auth/oidc/`);
 
     this.httpClient = httpClient;
@@ -184,14 +187,11 @@ export class Moodle {
 
     const pageJsonData = this._parseMoodlePageConfigFromHtml(resp2.data);
 
-    const userId = pageJsonData?.userId as number | any;
-    const moodleSessionKey = pageJsonData?.sesskey as string | any;
+    const userId = pageJsonData.userId as number;
+    const moodleSessionKey = pageJsonData.sesskey as string;
 
-    if (typeof userId !== 'number' || userId === 0) {
+    if (userId === 0) {
       throw new Error("Authentication failed, userId is invalid");
-    }
-    if (typeof moodleSessionKey !== 'string' || moodleSessionKey.length === 0) {
-      throw new Error("Authentication failed, sesskey is invalid");
     }
 
     const setCookieHeaders = resp.headers["set-cookie"];
@@ -210,6 +210,7 @@ export class Moodle {
     const moodleSessionCookie = moodleSessionCookieRaw.split("=")[1];
 
     console.log(`Authenticated as userId=${userId}, sesskey=${moodleSessionKey}, MoodleSession=${moodleSessionCookie}`);
+    this.moodleUserId = userId;
     this.moodleSessionCookie = moodleSessionCookie;
     this.moodleSessionKey = moodleSessionKey;
 
@@ -236,16 +237,12 @@ export class Moodle {
 
     const $ = loadHtml(resp.data);
     const fullname = $("h1").first().text().trim();
-    const usernameRef = $("a[href^='mailto']").attr("href");
-    if (!usernameRef) {
-      throw new Error("No mailto link found on profile page");
-    };
-
-    const username = decodeURIComponent(usernameRef).replace(/^mailto:/i, "");
+    const username = decodeURIComponent($("a[href^='mailto']").attr("href")!)
+      .replace(/^mailto:/i, "");
 
     const pageJsonData = this._parseMoodlePageConfigFromHtml($);
 
-    const userId = pageJsonData?.userId as number | any;
+    const userId = pageJsonData.userId as number;
 
     return { fullname, username, userId, };
   }
@@ -260,14 +257,18 @@ export class Moodle {
         F extends keyof FunctionDefinition ? FunctionDefinition[F][1] : unknown,
         null,
       ]
-    | [null, { message: string }]
+    | [null, { message: string, code: string | null }]
   > {
-    if (!this.client) {
+    if (!this.moodleClient) {
+      if (!this.moodleUserId) {
+        throw new Error("No Moodle user ID available, please authenticate first");
+      }
+
       if (!this.moodleSessionCookie || !this.moodleSessionKey) {
         throw new Error("No Moodle client or session available, please authenticate first");
       }
 
-      this.client = new MoodleClient(
+      this.moodleClient = new MoodleClient(
         config.moodle.url,
         this.moodleSessionCookie,
         this.moodleSessionKey,
@@ -275,7 +276,7 @@ export class Moodle {
     }
 
     try {
-      const res = await this.client.call(
+      const res = await this.moodleClient.call(
         func,
         ...(params as F extends keyof FunctionDefinition
           ? Record<never, never> extends FunctionDefinition[F][0]
@@ -290,8 +291,41 @@ export class Moodle {
           : unknown,
         null,
       ];
-    } catch (err: any) {
-      return [null, { message: err.message }];
+    } catch (err: MoodleAPIError | any) {
+      if (err?.cdde === "servicerequireslogin") {
+        // attempting reauth using Moodle OIDC and authCookies
+        try {
+          await this.authByCookies();
+        } catch (reauthErr: any) {
+          return [null, { message: (reauthErr as Error).message, code: null }];
+        }
+
+        // TODO: log reauth success and MoodleSession change
+
+        try {
+          await db.user.updateOne(
+            { moodleId: this.moodleUserId },
+            {
+              $set: {
+                moodleSessionCookie: this.moodleSessionCookie,
+                moodleSessionKey: this.moodleSessionKey,
+              },
+            },
+          );
+        } catch (dbErr: any) {
+          // TODO: log db update error
+        }
+
+        this.moodleClient = new MoodleClient(
+          config.moodle.url,
+          this.moodleSessionCookie!,
+          this.moodleSessionKey!,
+        );
+
+        return await this.call(func, ...params);
+      }
+
+      return [null, { message: err.message, code: err?.code }];
     }
   }
 }

--- a/apps/backend/src/library/moodle.ts
+++ b/apps/backend/src/library/moodle.ts
@@ -1,16 +1,254 @@
-import { MoodleClient } from "moodle-api";
+import { MoodleClient } from "./moodleClient";  // TODO: remove, use "moodle-api" directly
 import type { FunctionDefinition } from "moodle-api";
 import { z } from "zod";
 import { config } from "../config";
+import axios, { type AxiosInstance } from "axios";
+import { wrapper } from "axios-cookiejar-support";
+import { CookieJar } from "tough-cookie";
+import { load as loadHtml, type CheerioAPI } from "cheerio";
+
+interface Options {
+  authCookies?: MoodleAuthCookie[];
+  moodleSessionCookie?: string;
+  moodleSessionKey?: string;
+}
+
+interface MoodleAuthCookie {  // TODO: move to shared types
+  name: string;
+  value: string;
+}
+
+function validateForwardedHttpResponseStatus(status: number) {
+  return status >= 200 && status < 400;
+}
+
+interface MoodleStudentInfo {
+  fullname: string,
+  username: string,  // email
+  userId: number,
+}
 
 export class Moodle {
-  private client: MoodleClient;
+  protected client?: MoodleClient;
+  protected authCookies?: MoodleAuthCookie[];
+  protected httpClient?: AxiosInstance;
+  protected moodleSessionCookie?: string;
+  protected moodleSessionKey?: string;
 
-  constructor(token: string) {
-    this.client = new MoodleClient(config.moodle.url, token);
+  constructor(options: Options = {}) {
+    this.authCookies = options.authCookies;
+    this.moodleSessionCookie = options.moodleSessionCookie;
+    this.moodleSessionKey = options.moodleSessionKey;
   }
 
   static zCourseType = z.enum(["inprogress", "past", "future"]);
+
+  private _createHttpSession() {
+    const jar = new CookieJar();
+
+    const httpClient = wrapper(
+      axios.create({
+        jar,
+        withCredentials: true,
+        maxRedirects: 0,
+        validateStatus: validateForwardedHttpResponseStatus,
+        headers: {
+          "Sec-Fetch-Dest": "document",
+          "Sec-Fetch-Mode": "navigate",
+          "Sec-Fetch-Site": "none",
+          "Sec-Fetch-User": "?1",
+          "Sec-GPC": "1",
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0",
+        },
+      })
+    );
+
+    return { httpClient, jar };
+  }
+
+  private async _getFormAndData(url: string) {
+    if (!this.authCookies) {
+      throw new Error("No auth cookies provided");
+    }
+
+    const { httpClient } = this._createHttpSession();
+
+    const respSrc = await httpClient.get(url);
+    if (!(respSrc.status >= 300 && respSrc.status < 400 && respSrc.headers.location)) {
+      throw new Error(`Expected redirect from ${url}, got ${respSrc.status}`);
+    }
+
+    const redirectUrl = new URL(respSrc.headers.location, respSrc.config.url ?? url).toString();
+    console.log(`Redirect from ${url} to ${redirectUrl}`);
+
+    httpClient.defaults.headers.Cookie = this.authCookies.map(c => `${encodeURIComponent(c.name)}=${encodeURIComponent(c.value)}`).join("; ");
+
+    const resp = await httpClient.get(redirectUrl);
+    console.log(`GET ${url} -> ${resp.status}: ${resp.data}`);
+
+    const $ = loadHtml(resp.data);
+    const $form = $("form").first();
+    if ($form.length === 0) {
+      throw new Error("No (form) found on page");
+    }
+
+    const actionAttr = $form.attr("action") ?? "";
+    const baseUrl = resp.config.url ?? url;
+    const moodlePostUrl = new URL(actionAttr || ".", baseUrl).toString();
+
+    const moodlePostData: Record<string, string> = {};
+
+    $form.find("input[name]").each((_: any , el: any) => {
+      const name = $(el).attr("name")!;
+      const value = $(el).attr("value") ?? "";
+      const type = ($(el).attr("type") || "").toLowerCase();
+      const checked = $(el).is(":checked");
+      if (type === "checkbox" || type === "radio") {
+        if (checked) {
+          moodlePostData[name] = value;
+        }
+      } else {
+        moodlePostData[name] = value;
+      }
+    });
+
+    $form.find("select[name]").each((_: any, el: any) => {
+      const name = $(el).attr("name")!;
+      const $options = $(el).find("option");
+      const $selected = $options.filter("[selected]").first();
+      const value = $selected.length
+        ? ($selected.attr("value") ?? "")
+        : ($options.first().attr("value") ?? "");
+      moodlePostData[name] = value;
+    });
+
+    $form.find("textarea[name]").each((_: any, el: any) => {
+      const name = $(el).attr("name")!;
+      const value = $(el).text() ?? "";
+      moodlePostData[name] = value;
+    });
+
+    return { httpClient, moodlePostUrl, moodlePostData };
+  }
+
+  private _parseMoodlePageConfigFromHtml(html: string | CheerioAPI): any {
+    const $ = (typeof html === "string") ? loadHtml(html) : html;
+
+    const scriptTag = $("script")
+      .toArray()
+      .find((el) => $(el).text().includes('"wwwroot"'));
+
+    if (!scriptTag) {
+      throw new Error('No (script) tag with "wwwroot" found');
+    }
+
+    const scriptText = $(scriptTag).text();
+
+    const start = scriptText.indexOf('"wwwroot"') - 1;
+    if (start < 0) {
+      throw new Error('"wwwroot" not found in script text');
+    }
+
+    const end = scriptText.indexOf(";", start);
+    if (end < 0) {
+      throw new Error("Could not find trailing semicolon");
+    }
+
+    const jsonData: any = JSON.parse(scriptText.slice(start, end));
+    console.log(`Extracted JSON data: ${JSON.stringify(jsonData)}`);
+
+    return jsonData;
+  }
+
+  async authByCookies() {
+    const { httpClient, moodlePostUrl, moodlePostData } = await this._getFormAndData(`${config.moodle.url}/auth/oidc/`);
+
+    this.httpClient = httpClient;
+
+    console.log(`Posting to ${moodlePostUrl} with data: ${JSON.stringify(moodlePostData)}`);
+    const resp = await httpClient.post(moodlePostUrl, new URLSearchParams(moodlePostData), {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      maxRedirects: 0,
+      validateStatus: validateForwardedHttpResponseStatus,
+    });
+
+    if (!(validateForwardedHttpResponseStatus(resp.status) && resp.headers.location)) {
+      throw new Error("Unexpected response during cookie auth");
+    }
+
+    const resp2 = await httpClient.get(
+      new URL(resp.headers.location, moodlePostUrl).toString(),
+      { maxRedirects: 0 },
+    );
+
+    const pageJsonData = this._parseMoodlePageConfigFromHtml(resp2.data);
+
+    const userId = pageJsonData?.userId as number | any;
+    const moodleSessionKey = pageJsonData?.sesskey as string | any;
+
+    if (typeof userId !== 'number' || userId === 0) {
+      throw new Error("Authentication failed, userId is invalid");
+    }
+    if (typeof moodleSessionKey !== 'string' || moodleSessionKey.length === 0) {
+      throw new Error("Authentication failed, sesskey is invalid");
+    }
+
+    const setCookieHeaders = resp.headers["set-cookie"];
+    if (!setCookieHeaders || !Array.isArray(setCookieHeaders)) {
+      throw new Error("No set-cookie headers found");
+    }
+
+    const moodleSessionCookieRaw = setCookieHeaders
+      .map(c => c.split(";")[0])
+      .find(c => c.startsWith("MoodleSession="));
+
+    if (!moodleSessionCookieRaw) {
+      throw new Error("MoodleSession cookie not found");
+    }
+
+    const moodleSessionCookie = moodleSessionCookieRaw.split("=")[1];
+
+    console.log(`Authenticated as userId=${userId}, sesskey=${moodleSessionKey}, MoodleSession=${moodleSessionCookie}`);
+    this.moodleSessionCookie = moodleSessionCookie;
+    this.moodleSessionKey = moodleSessionKey;
+
+    return { userId, moodleSessionCookie, moodleSessionKey };
+  }
+
+  private setMoodleCookies(httpClient: AxiosInstance) {
+    if (!this.moodleSessionCookie) {
+      throw new Error("No MoodleSession cookie available");
+    }
+
+    httpClient.defaults.headers.Cookie = `MoodleSession=${encodeURIComponent(this.moodleSessionCookie)}`;
+  }
+
+  async getStudentInfo(): Promise<MoodleStudentInfo> {
+    if (!this.httpClient) {
+      this.httpClient = this._createHttpSession().httpClient;
+    }
+    const httpClient = this.httpClient;
+
+    this.setMoodleCookies(httpClient);
+
+    const resp = await httpClient.get(`${config.moodle.url}/user/profile.php`);
+
+    const $ = loadHtml(resp.data);
+    const fullname = $("h1").first().text().trim();
+    const usernameRef = $("a[href^='mailto']").attr("href");
+    if (!usernameRef) {
+      throw new Error("No mailto link found on profile page");
+    };
+
+    const username = decodeURIComponent(usernameRef).replace(/^mailto:/i, "");
+
+    const pageJsonData = this._parseMoodlePageConfigFromHtml($);
+
+    const userId = pageJsonData?.userId as number | any;
+
+    return { fullname, username, userId, };
+  }
 
   async call<F extends keyof FunctionDefinition | (string & {})>(
     func: F,
@@ -24,6 +262,18 @@ export class Moodle {
       ]
     | [null, { message: string }]
   > {
+    if (!this.client) {
+      if (!this.moodleSessionCookie || !this.moodleSessionKey) {
+        throw new Error("No Moodle client or session available, please authenticate first");
+      }
+
+      this.client = new MoodleClient(
+        config.moodle.url,
+        this.moodleSessionCookie,
+        this.moodleSessionKey,
+      );
+    }
+
     try {
       const res = await this.client.call(
         func,

--- a/apps/backend/src/library/moodle.ts
+++ b/apps/backend/src/library/moodle.ts
@@ -200,10 +200,7 @@ export class Moodle {
       throw new Error("Could not find trailing semicolon");
     }
 
-    const jsonData: any = JSON.parse(scriptText.slice(start, end));
-    console.log(`Extracted JSON data: ${JSON.stringify(jsonData)}`);
-
-    return jsonData;
+    return JSON.parse(scriptText.slice(start, end));
   }
 
   async authByCookies() {
@@ -313,7 +310,6 @@ export class Moodle {
     const $ = loadHtml(resp.data);
 
     const $gradeEls = $($("table.generaltable tr[data-hidden='false']").toArray().slice(1).slice(0, -1).slice(0, -1));
-    console.log(`Found ${$gradeEls.length} grade elements`);
 
     const grades: MoodleGrade[] = $gradeEls.map((_, el) => {
       const $gradeEl = $(el);

--- a/apps/backend/src/library/moodle.ts
+++ b/apps/backend/src/library/moodle.ts
@@ -292,7 +292,7 @@ export class Moodle {
         null,
       ];
     } catch (err: MoodleAPIError | any) {
-      if (err?.cdde === "servicerequireslogin") {
+      if (err?.code === "servicerequireslogin") {
         // attempting reauth using Moodle OIDC and authCookies
         try {
           await this.authByCookies();

--- a/apps/backend/src/library/moodle.ts
+++ b/apps/backend/src/library/moodle.ts
@@ -8,7 +8,7 @@ import { wrapper } from "axios-cookiejar-support";
 import { CookieJar } from "tough-cookie";
 import { load as loadHtml, type CheerioAPI } from "cheerio";
 import { db } from "./db";
-import { type MoodleGrade } from "@remoodle/types";
+import type { MoodleGrade } from "@remoodle/types";
 import { murmurhash3_32 } from "./murmurhash3_32";
 
 interface Options {
@@ -32,6 +32,11 @@ interface MoodleStudentInfo {
   username: string,  // email
   userId: number,
 }
+
+const ignoreGradeNames = new Set([
+  "Register(not to edit)",
+  "Register(not to edit) total",
+]);
 
 interface GradeBaseData {
   itemtype: string;
@@ -307,13 +312,23 @@ export class Moodle {
 
     const $ = loadHtml(resp.data);
 
-    const $gradeEls = $($("table.generaltable tr.cat_936[data-hidden='false']").toArray().slice(0, 8).slice(0, -1));
+    const $gradeEls = $($("table.generaltable tr[data-hidden='false']").toArray().slice(1).slice(0, -1).slice(0, -1));
+    console.log(`Found ${$gradeEls.length} grade elements`);
 
     const grades: MoodleGrade[] = $gradeEls.map((_, el) => {
       const $gradeEl = $(el);
+      if ($gradeEl.hasClass("spacer")) {
+        return null;
+      }
 
       const $nameAndIdEl = $(".gradeitemheader", $gradeEl).first();
-      const name = $nameAndIdEl.attr("title")!.trim();
+      if (!$nameAndIdEl.length) {
+        return null;
+      }
+      const name = $nameAndIdEl.text().trim();
+      if (ignoreGradeNames.has(name)) {
+        return null;
+      }
       const foundIdStr = $nameAndIdEl.attr("href")?.split("id=", 2)?.[1];
 
       const baseGradeData = {
@@ -322,8 +337,8 @@ export class Moodle {
       };
       const gradeId = foundIdStr ? parseInt(foundIdStr, 10) : this._calculateGradeIdHash(baseGradeData);
 
-      const gradeValueFormatted = $("td.column-grade", $gradeEl).first().text().trim().replace("-", "0.00");
-      const gradeValueRaw = parseFloat(gradeValueFormatted);
+      const gradeValueFormatted = $("td.column-grade", $gradeEl).first().text().trim();
+      const gradeValueRaw = parseFloat(gradeValueFormatted) ?? null;
       const gradeValueRange = $("td.column-range", $gradeEl).first().text().trim().split("–", 2);
       const gradeValueMin = parseFloat(gradeValueRange[0]);
       const gradeValueMax = parseFloat(gradeValueRange[1]);
@@ -342,7 +357,7 @@ export class Moodle {
       };
     }).get();
 
-    return grades;
+    return grades.filter((g): g is MoodleGrade => g !== null);
   }
 
   async call<F extends keyof FunctionDefinition | (string & {})>(

--- a/apps/backend/src/library/moodle.ts
+++ b/apps/backend/src/library/moodle.ts
@@ -8,6 +8,8 @@ import { wrapper } from "axios-cookiejar-support";
 import { CookieJar } from "tough-cookie";
 import { load as loadHtml, type CheerioAPI } from "cheerio";
 import { db } from "./db";
+import { type MoodleGrade } from "@remoodle/types";
+import { murmurhash3_32 } from "./murmurhash3_32";
 
 interface Options {
   moodleUserId?: number,
@@ -30,6 +32,45 @@ interface MoodleStudentInfo {
   username: string,  // email
   userId: number,
 }
+
+interface GradeBaseData {
+  itemtype: string;
+  itemmodule: string | null;
+  idnumber?: string;
+}
+
+const gradeNamesToBaseData: Record<string, GradeBaseData> = {
+  "Register Midterm": {
+    itemtype: "manual",
+    itemmodule: null,
+    idnumber: "register_midterm",
+  },
+  "Register Endterm": {
+    itemtype: "manual",
+    itemmodule: null,
+    idnumber: "register_endterm",
+  },
+  "Register Term": {
+    itemtype: "manual",
+    itemmodule: null,
+    idnumber: "register_term",
+  },
+  "Register Final": {
+    itemtype: "manual",
+    itemmodule: null,
+    idnumber: "register_final",
+  },
+  "Attendance": {
+    itemtype: "mod",
+    itemmodule: "attendance",
+    idnumber: "register_attendance",
+  }
+};
+
+const defaultGradeBaseData: GradeBaseData = {
+  itemtype: "mod",
+  itemmodule: "assign",
+};
 
 export class Moodle {
   protected httpClient?: AxiosInstance;
@@ -217,6 +258,13 @@ export class Moodle {
     return { userId, moodleSessionCookie, moodleSessionKey };
   }
 
+  private _getHttpClient(): AxiosInstance {
+    if (!this.httpClient) {
+      this.httpClient = this._createHttpSession().httpClient;
+    }
+    return this.httpClient;
+  }
+
   private setMoodleCookies(httpClient: AxiosInstance) {
     if (!this.moodleSessionCookie) {
       throw new Error("No MoodleSession cookie available");
@@ -226,11 +274,7 @@ export class Moodle {
   }
 
   async getStudentInfo(): Promise<MoodleStudentInfo> {
-    if (!this.httpClient) {
-      this.httpClient = this._createHttpSession().httpClient;
-    }
-    const httpClient = this.httpClient;
-
+    const httpClient = this._getHttpClient();
     this.setMoodleCookies(httpClient);
 
     const resp = await httpClient.get(`${config.moodle.url}/user/profile.php`);
@@ -245,6 +289,60 @@ export class Moodle {
     const userId = pageJsonData.userId as number;
 
     return { fullname, username, userId, };
+  }
+
+  private _calculateGradeIdHash(baseGrade: GradeBaseData & { name: string }): number {
+    return murmurhash3_32(`${baseGrade.name}|${baseGrade.itemtype}|${baseGrade.itemmodule ?? ""}|${baseGrade.idnumber ?? ""}`, 1337);
+  }
+
+  async getGrades({ courseId }: { courseId: number | string }): Promise<MoodleGrade[]> {
+    if (!this.moodleUserId) {
+      throw new Error("No Moodle user ID available, please authenticate first");
+    }
+
+    const httpClient = this._getHttpClient();
+    this.setMoodleCookies(httpClient);
+
+    const resp = await httpClient.get(`${config.moodle.url}/course/user.php?mode=grade&id=${courseId}&user=${this.moodleUserId}`);
+
+    const $ = loadHtml(resp.data);
+
+    const $gradeEls = $($("table.generaltable tr.cat_936[data-hidden='false']").toArray().slice(0, 8).slice(0, -1));
+
+    const grades: MoodleGrade[] = $gradeEls.map((_, el) => {
+      const $gradeEl = $(el);
+
+      const $nameAndIdEl = $(".gradeitemheader", $gradeEl).first();
+      const name = $nameAndIdEl.attr("title")!.trim();
+      const foundIdStr = $nameAndIdEl.attr("href")?.split("id=", 2)?.[1];
+
+      const baseGradeData = {
+        name,
+        ...(gradeNamesToBaseData[name] ?? defaultGradeBaseData),
+      };
+      const gradeId = foundIdStr ? parseInt(foundIdStr, 10) : this._calculateGradeIdHash(baseGradeData);
+
+      const gradeValueFormatted = $("td.column-grade", $gradeEl).first().text().trim().replace("-", "0.00");
+      const gradeValueRaw = parseFloat(gradeValueFormatted);
+      const gradeValueRange = $("td.column-range", $gradeEl).first().text().trim().split("–", 2);
+      const gradeValueMin = parseFloat(gradeValueRange[0]);
+      const gradeValueMax = parseFloat(gradeValueRange[1]);
+
+      return {
+        id: gradeId,
+        itemname: name,
+        itemtype: baseGradeData.itemtype,
+        itemmodule: baseGradeData.itemmodule ?? undefined,
+        // iteminstance: -1,  // TODO: review usage with assignments rewriting
+        graderaw: gradeValueRaw,
+        gradeformatted: gradeValueFormatted,
+        grademin: gradeValueMin,
+        grademax: gradeValueMax,
+        // cmid: -1,  // TODO: review usage with assignments rewriting
+      };
+    }).get();
+
+    return grades;
   }
 
   async call<F extends keyof FunctionDefinition | (string & {})>(
@@ -294,6 +392,7 @@ export class Moodle {
     } catch (err: MoodleAPIError | any) {
       if (err?.code === "servicerequireslogin") {
         // attempting reauth using Moodle OIDC and authCookies
+        // TODO: use user.health
         try {
           await this.authByCookies();
         } catch (reauthErr: any) {

--- a/apps/backend/src/library/moodleClient.ts
+++ b/apps/backend/src/library/moodleClient.ts
@@ -2,20 +2,20 @@ import { MoodleClient as _MoodleClient } from "moodle-api";
 import type { FunctionDefinition } from "moodle-api";
 
 export class MoodleAPIError extends Error {
-    code: string;
+  code: string;
 
-    constructor(message: string, { code }: { code: string }) {
-        super(message);
+  constructor(message: string, { code }: { code: string }) {
+    super(message);
 
-        this.code = code
+    this.code = code;
     }
 }
 
 export class MoodleClient extends _MoodleClient {
   protected sessionKey: string;
 
-  constructor(base_url: string | URL, token: string, sessionKey: string) {
-    super(base_url, token);
+  constructor(base_url: string | URL, sessionCookie: string, sessionKey: string) {
+    super(base_url, sessionCookie);
 
     this.sessionKey = sessionKey;
   }

--- a/apps/backend/src/library/moodleClient.ts
+++ b/apps/backend/src/library/moodleClient.ts
@@ -53,7 +53,7 @@ export class MoodleClient extends _MoodleClient {
 		const json: any = await response.json();
     const jsonFixed = (json ? json[0] : {});
     if (jsonFixed.exception) {
-			throw new MoodleAPIError( jsonFixed.message, { code: jsonFixed.errorcode } );
+			throw new MoodleAPIError( jsonFixed.message, { code: jsonFixed.exception.errorcode } );
 		}
 		return jsonFixed?.data || {};
 	}

--- a/apps/backend/src/library/moodleClient.ts
+++ b/apps/backend/src/library/moodleClient.ts
@@ -1,0 +1,50 @@
+import { MoodleClient as _MoodleClient } from "moodle-api";
+import type { FunctionDefinition } from "moodle-api";
+
+export class MoodleClient extends _MoodleClient {
+  protected sessionKey: string;
+
+  constructor(base_url: string | URL, token: string, sessionKey: string) {
+    super(base_url, token);
+
+    this.sessionKey = sessionKey;
+  }
+
+  public async call<F extends keyof FunctionDefinition | (string & {})>(
+		func: F,
+		...params: F extends keyof FunctionDefinition
+			? Record<never, never> extends FunctionDefinition[F][0]
+				? []
+				: [FunctionDefinition[F][0]]
+			: [Record<string, unknown>]
+	): Promise<F extends keyof FunctionDefinition ? FunctionDefinition[F][1] : unknown> {
+		const url = new URL("/lib/ajax/service.php", this.base);
+		url.searchParams.append("sesskey", this.sessionKey);
+
+		const body = JSON.stringify([{
+      index: 0,
+      methodname: func,
+      args: params ? params[0] : {},
+    }]);
+    console.log(`Moodle API Call: ${func} with body: ${body}`);
+
+		const response = await fetch(url.toString(), {
+			method: "POST",
+			headers: {
+        "Cookie": "MoodleSession=" + this.token,
+				"Content-Type": "application/json",
+			},
+			body,
+		});
+		if (!response.ok) {
+			throw new Error(`HTTP Error: ${response.status} ${response.statusText}`);
+		}
+
+		const json: any = await response.json();
+    const jsonFixed = (json ? json[0] : {});
+    if (jsonFixed.exception) {
+			throw new Error(jsonFixed.message);
+		}
+		return jsonFixed?.data || {};
+	}
+}

--- a/apps/backend/src/library/moodleClient.ts
+++ b/apps/backend/src/library/moodleClient.ts
@@ -1,6 +1,16 @@
 import { MoodleClient as _MoodleClient } from "moodle-api";
 import type { FunctionDefinition } from "moodle-api";
 
+export class MoodleAPIError extends Error {
+    code: string;
+
+    constructor(message: string, { code }: { code: string }) {
+        super(message);
+
+        this.code = code
+    }
+}
+
 export class MoodleClient extends _MoodleClient {
   protected sessionKey: string;
 
@@ -43,7 +53,7 @@ export class MoodleClient extends _MoodleClient {
 		const json: any = await response.json();
     const jsonFixed = (json ? json[0] : {});
     if (jsonFixed.exception) {
-			throw new Error(jsonFixed.message);
+			throw new MoodleAPIError( jsonFixed.message, { code: jsonFixed.errorcode } );
 		}
 		return jsonFixed?.data || {};
 	}

--- a/apps/backend/src/library/murmurhash3_32.ts
+++ b/apps/backend/src/library/murmurhash3_32.ts
@@ -1,0 +1,54 @@
+export const murmurhash3_32 = (key: string, seed = 0): number => {
+  let h = seed >>> 0;
+  const remainder = key.length & 3; // key.length % 4
+  const bytes = key.length - remainder;
+  const c1 = 0xcc9e2d51;
+  const c2 = 0x1b873593;
+  let i = 0;
+
+  while (i < bytes) {
+    let k = (key.charCodeAt(i) & 0xff) |
+            ((key.charCodeAt(i + 1) & 0xff) << 8) |
+            ((key.charCodeAt(i + 2) & 0xff) << 16) |
+            ((key.charCodeAt(i + 3) & 0xff) << 24);
+    i += 4;
+
+    k = Math.imul(k, c1);
+    k = (k << 15) | (k >>> 17);
+    k = Math.imul(k, c2);
+
+    h ^= k;
+    h = (h << 13) | (h >>> 19);
+    h = (Math.imul(h, 5) + 0xe6546b64) >>> 0;
+  }
+
+  let k1 = 0;
+  switch (remainder) {
+    case 3: {
+      k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
+      break;
+    }
+    case 2: {
+      k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
+      break;
+    }
+    case 1: {
+      k1 ^= key.charCodeAt(i) & 0xff;
+      k1 = Math.imul(k1, c1);
+      k1 = (k1 << 15) | (k1 >>> 17);
+      k1 = Math.imul(k1, c2);
+      h ^= k1;
+      break;
+    }
+  }
+
+  // finalization mix (fmix32)
+  h ^= key.length;
+  h ^= h >>> 16;
+  h  = Math.imul(h, 0x85ebca6b);
+  h ^= h >>> 13;
+  h  = Math.imul(h, 0xc2b2ae35);
+  h ^= h >>> 16;
+
+  return h >>> 0; // unsigned 32-bit
+};

--- a/apps/backend/src/library/murmurhash3_32.ts
+++ b/apps/backend/src/library/murmurhash3_32.ts
@@ -1,54 +1,56 @@
-export const murmurhash3_32 = (key: string, seed = 0): number => {
-  let h = seed >>> 0;
-  const remainder = key.length & 3; // key.length % 4
-  const bytes = key.length - remainder;
+export function murmurhash3_32(key: string, seed: number): number {
+  const rem = key.length & 3;
+  const bytes = key.length - rem;
+  let h1 = seed;
   const c1 = 0xcc9e2d51;
   const c2 = 0x1b873593;
   let i = 0;
+  let k1 = 0;
 
   while (i < bytes) {
-    let k = (key.charCodeAt(i) & 0xff) |
-            ((key.charCodeAt(i + 1) & 0xff) << 8) |
-            ((key.charCodeAt(i + 2) & 0xff) << 16) |
-            ((key.charCodeAt(i + 3) & 0xff) << 24);
-    i += 4;
+    k1 =
+      (key.charCodeAt(i) & 0xff) |
+      ((key.charCodeAt(++i) & 0xff) << 8) |
+      ((key.charCodeAt(++i) & 0xff) << 16) |
+      ((key.charCodeAt(++i) & 0xff) << 24);
+    i++;
 
-    k = Math.imul(k, c1);
-    k = (k << 15) | (k >>> 17);
-    k = Math.imul(k, c2);
+    k1 = ((k1 & 0xffff) * c1 + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
+    k1 = (k1 << 15) | (k1 >>> 17);
+    k1 = ((k1 & 0xffff) * c2 + ((((k1 >> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
 
-    h ^= k;
-    h = (h << 13) | (h >>> 19);
-    h = (Math.imul(h, 5) + 0xe6546b64) >>> 0;
+    h1 ^= k1;
+    h1 = (h1 << 13) | (h1 >>> 19);
+
+    const h1b = ((h1 & 0xffff) * 5 + ((((h1 >>> 16) * 5) & 0xffff) << 16)) & 0xffffffff;
+    h1 = (h1b & 0xffff) + 0x6b64 + (((h1b >>> 16) + 0xe654) << 16);
   }
 
-  let k1 = 0;
-  switch (remainder) {
+  k1 = 0;
+
+  switch (rem) {
     case 3: {
       k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
-      break;
     }
     case 2: {
       k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
-      break;
     }
     case 1: {
       k1 ^= key.charCodeAt(i) & 0xff;
-      k1 = Math.imul(k1, c1);
+      k1 = ((k1 & 0xffff) * c1 + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
       k1 = (k1 << 15) | (k1 >>> 17);
-      k1 = Math.imul(k1, c2);
-      h ^= k1;
-      break;
+      k1 = ((k1 & 0xffff) * c2 + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
+      h1 ^= k1;
     }
   }
 
-  // finalization mix (fmix32)
-  h ^= key.length;
-  h ^= h >>> 16;
-  h  = Math.imul(h, 0x85ebca6b);
-  h ^= h >>> 13;
-  h  = Math.imul(h, 0xc2b2ae35);
-  h ^= h >>> 16;
+  h1 ^= key.length;
 
-  return h >>> 0; // unsigned 32-bit
-};
+  h1 ^= h1 >>> 16;
+  h1 = ((h1 & 0xffff) * 0x85ebca6b + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
+  h1 ^= h1 >>> 13;
+  h1 = ((h1 & 0xffff) * 0xc2b2ae35 + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16)) & 0xffffffff;
+  h1 ^= h1 >>> 16;
+
+  return h1 >>> 0;
+}

--- a/apps/backend/src/services/api/router/v2.ts
+++ b/apps/backend/src/services/api/router/v2.ts
@@ -438,7 +438,7 @@ const userRoutes = new Hono<{
 
       return ctx.json(
         courses.map((course) => {
-          return { ...course.data };
+          return course.data;
         }),
       );
     },
@@ -532,7 +532,7 @@ const userRoutes = new Hono<{
         });
       }
 
-      return ctx.json({ ...course.data });
+      return ctx.json(course.data);
     },
   )
   // TODO: rewrite assignments fetching

--- a/apps/backend/src/services/api/router/v2.ts
+++ b/apps/backend/src/services/api/router/v2.ts
@@ -429,9 +429,7 @@ const userRoutes = new Hono<{
 
       return ctx.json(
         courses.map((course) => {
-          return {
-            ...course.data,
-          };
+          return { ...course.data };
         }),
       );
     },

--- a/apps/backend/src/services/api/router/v2.ts
+++ b/apps/backend/src/services/api/router/v2.ts
@@ -34,8 +34,155 @@ const authRoutes = new Hono<{
   };
 }>()
   .use("*", authMiddleware(["Telegram"], false))
+  // .post(
+  //   "/token",
+  //   rateLimiter({
+  //     ...defaultRules,
+  //     windowMs: 1 * 60 * 60 * 1000, // 1 hour
+  //     limit: 10,
+  //   }),
+  //   zValidator(
+  //     "json",
+  //     z.object({
+  //       moodleToken: z.string(),
+  //       handle: z.string().optional(),
+  //       password: z.string().optional(),
+  //     }),
+  //   ),
+  //   async (ctx) => {
+  //     const { handle, moodleToken, password } = ctx.req.valid("json");
+  //
+  //     const client = new Moodle(moodleToken);
+  //     const [student, error] = await client.call(
+  //       "core_webservice_get_site_info",
+  //     );
+  //     if (error) {
+  //       throw new HTTPException(500, { message: error.message });
+  //     }
+  //
+  //     const telegramId = ctx.get("telegramId");
+  //
+  //     const currentUser = await db.user.findOne({ telegramId });
+  //
+  //     const currentStudentUser = await db.user.findOne({ moodleToken });
+  //
+  //     let syncedUserId: string | undefined;
+  //     let shouldSync: boolean = false;
+  //
+  //     if (currentUser || currentStudentUser) {
+  //       const userId = currentUser?._id ?? currentStudentUser?._id;
+  //
+  //       await db.user.updateOne(
+  //         { _id: userId },
+  //         {
+  //           $set: {
+  //             name: student.fullname,
+  //             username: student.username,
+  //             moodleId: student.userid,
+  //             moodleToken,
+  //             telegramId,
+  //             health: 7,
+  //           },
+  //         },
+  //       );
+  //
+  //       if (currentUser && !currentStudentUser) {
+  //         logger.api.info({
+  //           msg: "student account changed",
+  //           userId,
+  //           currentUser,
+  //           currentStudentUser,
+  //         });
+  //
+  //         await db.course.updateMany(
+  //           { moodleId: currentUser.moodleId },
+  //           { $set: { classification: "past" } },
+  //         );
+  //
+  //         shouldSync = true;
+  //       }
+  //
+  //       syncedUserId = userId;
+  //     }
+  //
+  //     if (!currentStudentUser && !currentUser) {
+  //       try {
+  //         const user = (await db.user.create({
+  //           name: student.fullname,
+  //           username: student.username,
+  //           handle: handle,
+  //           moodleId: student.userid,
+  //           moodleToken,
+  //           ...(telegramId && { telegramId }),
+  //           ...(password && { password: hashPassword(password) }),
+  //         })) as IUser;
+  //
+  //         const { _id: userId } = user;
+  //
+  //         syncedUserId = userId;
+  //         shouldSync = true;
+  //
+  //         try {
+  //           increaseUserCounter();
+  //
+  //           await createAlert({
+  //             event: "user.sync",
+  //             data: { userId, telegramId, student },
+  //           });
+  //         } catch (error: any) {
+  //           logger.api.error(error);
+  //         }
+  //       } catch (error: any) {
+  //         throw new HTTPException(500, {
+  //           message: "Failed to create user" + error,
+  //         });
+  //       }
+  //     }
+  //
+  //     if (shouldSync && syncedUserId) {
+  //       try {
+  //         await syncUserData(syncedUserId);
+  //       } catch (error: any) {
+  //         throw new HTTPException(500, {
+  //           message: "Failed to sync data: " + error.message,
+  //         });
+  //       }
+  //     }
+  //
+  //     const user: IUser | null = await db.user.findOne({
+  //       _id: syncedUserId,
+  //     });
+  //
+  //     if (!user) {
+  //       throw new HTTPException(404, {
+  //         message: "User not found",
+  //       });
+  //     }
+  //
+  //     try {
+  //       const { accessToken, refreshToken } = issueTokens(
+  //         user._id,
+  //         user.moodleId,
+  //       );
+  //
+  //       // TODO: Sanitize this properly
+  //       user.password = "***";
+  //       user.moodleToken = "***";
+  //
+  //       return ctx.json({
+  //         user,
+  //         accessToken,
+  //         refreshToken,
+  //       });
+  //     } catch (error: any) {
+  //       throw new HTTPException(500, {
+  //         message: error.message,
+  //       });
+  //     }
+  //   },
+  // )
   .post(
-    "/token",
+    "/cookies",
     rateLimiter({
       ...defaultRules,
       windowMs: 1 * 60 * 60 * 1000, // 1 hour
@@ -44,27 +191,44 @@ const authRoutes = new Hono<{
     zValidator(
       "json",
       z.object({
-        moodleToken: z.string(),
-        handle: z.string().optional(),
-        password: z.string().optional(),
+        moodleAuthCookies: (z
+          .array(
+            z.object({
+              name: z.string(),
+              value: z.string(),
+            })
+          )
+          .min(1)
+          .refine(
+            (arr) => {
+              const names = arr.map(c => c.name.trim().toLowerCase());
+              return new Set(names).size === names.length;
+            },
+            { message: "Duplicate cookie names are not allowed" },
+          )
+        ),
+        telegramOtp: z.string(),
       }),
     ),
     async (ctx) => {
-      const { handle, moodleToken, password } = ctx.req.valid("json");
+      const { moodleAuthCookies, telegramOtp } = ctx.req.valid("json");
 
-      const client = new Moodle(moodleToken);
-      const [student, error] = await client.call(
-        "core_webservice_get_site_info",
-      );
-      if (error) {
-        throw new HTTPException(500, { message: error.message });
+      const telegramId = await db.telegramToken.get(telegramOtp);
+
+      if (!telegramId) {
+        throw new HTTPException(400, { message: "Invalid or expired token" });
       }
 
-      const telegramId = ctx.get("telegramId");
+      const moodleClient = new Moodle({authCookies: moodleAuthCookies});
+      const { userId: moodleUserId, moodleSessionCookie, moodleSessionKey } = await moodleClient.authByCookies();
+
+      await db.telegramToken.remove(telegramOtp);
+
+      const student = await moodleClient.getStudentInfo();
 
       const currentUser = await db.user.findOne({ telegramId });
 
-      const currentStudentUser = await db.user.findOne({ moodleToken });
+      const currentStudentUser = await db.user.findOne({ moodleUserId });
 
       let syncedUserId: string | undefined;
       let shouldSync: boolean = false;
@@ -78,8 +242,10 @@ const authRoutes = new Hono<{
             $set: {
               name: student.fullname,
               username: student.username,
-              moodleId: student.userid,
-              moodleToken,
+              moodleId: student.userId,
+              moodleAuthCookies,
+              moodleSessionCookie,
+              moodleSessionKey,
               telegramId,
               health: 7,
             },
@@ -110,11 +276,11 @@ const authRoutes = new Hono<{
           const user = (await db.user.create({
             name: student.fullname,
             username: student.username,
-            handle: handle,
-            moodleId: student.userid,
-            moodleToken,
+            moodleId: student.userId,
+            moodleAuthCookies,
+            moodleSessionCookie,
+            moodleSessionKey,
             ...(telegramId && { telegramId }),
-            ...(password && { password: hashPassword(password) }),
           })) as IUser;
 
           const { _id: userId } = user;
@@ -345,7 +511,10 @@ const userRoutes = new Hono<{
           });
         }
 
-        const client = new Moodle(user.moodleToken);
+        const client = new Moodle({
+          moodleSessionCookie: user.moodleSessionCookie,
+          moodleSessionKey: user.moodleSessionKey,
+        });
 
         const [response, error] = await client.call(
           "core_calendar_get_action_events_by_timesort",
@@ -388,6 +557,7 @@ const userRoutes = new Hono<{
         userId,
         ...(status && { classification: status }),
       });
+      console.log(`User ${userId} has ${courses.length} courses in DB with status ${status}`);
 
       if (!courses.length) {
         const user = await db.user.findById(userId);
@@ -398,11 +568,14 @@ const userRoutes = new Hono<{
           });
         }
 
-        const client = new Moodle(user.moodleToken);
+        const client = new Moodle({
+          moodleSessionCookie: user.moodleSessionCookie,
+          moodleSessionKey: user.moodleSessionKey,
+        });
 
         const [response, error] = await client.call(
           "core_course_get_enrolled_courses_by_timeline_classification",
-          { classification: status ?? null },
+          { classification: status ?? "all" },  // NOTE: select specific classification from https://github.com/moodle/moodle/blob/a828ba12c1796bb6f22a705ad61202be5b26fab2/public/course/externallib.php#L4019-L4040
         );
 
         if (error) {
@@ -490,7 +663,10 @@ const userRoutes = new Hono<{
           });
         }
 
-        const client = new Moodle(user.moodleToken);
+        const client = new Moodle({
+          moodleSessionCookie: user.moodleSessionCookie,
+          moodleSessionKey: user.moodleSessionKey,
+        });
         const [data, error] = await client.call("core_course_get_contents", {
           courseid: parseInt(courseId),
         });
@@ -523,7 +699,10 @@ const userRoutes = new Hono<{
       });
     }
 
-    const client = new Moodle(user.moodleToken);
+    const client = new Moodle({
+      moodleSessionCookie: user.moodleSessionCookie,
+      moodleSessionKey: user.moodleSessionKey,
+    });
 
     const [response, error] = await client.call("mod_assign_get_assignments", {
       courseids: [parseInt(courseId)],
@@ -559,7 +738,10 @@ const userRoutes = new Hono<{
         });
       }
 
-      const client = new Moodle(user.moodleToken);
+      const client = new Moodle({
+        moodleSessionCookie: user.moodleSessionCookie,
+        moodleSessionKey: user.moodleSessionKey,
+      });
 
       const [response, error] = await client.call(
         "gradereport_user_get_grade_items",

--- a/apps/backend/src/services/api/router/v2.ts
+++ b/apps/backend/src/services/api/router/v2.ts
@@ -34,153 +34,6 @@ const authRoutes = new Hono<{
   };
 }>()
   .use("*", authMiddleware(["Telegram"], false))
-  // .post(
-  //   "/token",
-  //   rateLimiter({
-  //     ...defaultRules,
-  //     windowMs: 1 * 60 * 60 * 1000, // 1 hour
-  //     limit: 10,
-  //   }),
-  //   zValidator(
-  //     "json",
-  //     z.object({
-  //       moodleToken: z.string(),
-  //       handle: z.string().optional(),
-  //       password: z.string().optional(),
-  //     }),
-  //   ),
-  //   async (ctx) => {
-  //     const { handle, moodleToken, password } = ctx.req.valid("json");
-  //
-  //     const client = new Moodle(moodleToken);
-  //     const [student, error] = await client.call(
-  //       "core_webservice_get_site_info",
-  //     );
-  //     if (error) {
-  //       throw new HTTPException(500, { message: error.message });
-  //     }
-  //
-  //     const telegramId = ctx.get("telegramId");
-  //
-  //     const currentUser = await db.user.findOne({ telegramId });
-  //
-  //     const currentStudentUser = await db.user.findOne({ moodleToken });
-  //
-  //     let syncedUserId: string | undefined;
-  //     let shouldSync: boolean = false;
-  //
-  //     if (currentUser || currentStudentUser) {
-  //       const userId = currentUser?._id ?? currentStudentUser?._id;
-  //
-  //       await db.user.updateOne(
-  //         { _id: userId },
-  //         {
-  //           $set: {
-  //             name: student.fullname,
-  //             username: student.username,
-  //             moodleId: student.userid,
-  //             moodleToken,
-  //             telegramId,
-  //             health: 7,
-  //           },
-  //         },
-  //       );
-  //
-  //       if (currentUser && !currentStudentUser) {
-  //         logger.api.info({
-  //           msg: "student account changed",
-  //           userId,
-  //           currentUser,
-  //           currentStudentUser,
-  //         });
-  //
-  //         await db.course.updateMany(
-  //           { moodleId: currentUser.moodleId },
-  //           { $set: { classification: "past" } },
-  //         );
-  //
-  //         shouldSync = true;
-  //       }
-  //
-  //       syncedUserId = userId;
-  //     }
-  //
-  //     if (!currentStudentUser && !currentUser) {
-  //       try {
-  //         const user = (await db.user.create({
-  //           name: student.fullname,
-  //           username: student.username,
-  //           handle: handle,
-  //           moodleId: student.userid,
-  //           moodleToken,
-  //           ...(telegramId && { telegramId }),
-  //           ...(password && { password: hashPassword(password) }),
-  //         })) as IUser;
-  //
-  //         const { _id: userId } = user;
-  //
-  //         syncedUserId = userId;
-  //         shouldSync = true;
-  //
-  //         try {
-  //           increaseUserCounter();
-  //
-  //           await createAlert({
-  //             event: "user.sync",
-  //             data: { userId, telegramId, student },
-  //           });
-  //         } catch (error: any) {
-  //           logger.api.error(error);
-  //         }
-  //       } catch (error: any) {
-  //         throw new HTTPException(500, {
-  //           message: "Failed to create user" + error,
-  //         });
-  //       }
-  //     }
-  //
-  //     if (shouldSync && syncedUserId) {
-  //       try {
-  //         await syncUserData(syncedUserId);
-  //       } catch (error: any) {
-  //         throw new HTTPException(500, {
-  //           message: "Failed to sync data: " + error.message,
-  //         });
-  //       }
-  //     }
-  //
-  //     const user: IUser | null = await db.user.findOne({
-  //       _id: syncedUserId,
-  //     });
-  //
-  //     if (!user) {
-  //       throw new HTTPException(404, {
-  //         message: "User not found",
-  //       });
-  //     }
-  //
-  //     try {
-  //       const { accessToken, refreshToken } = issueTokens(
-  //         user._id,
-  //         user.moodleId,
-  //       );
-  //
-  //       // TODO: Sanitize this properly
-  //       user.password = "***";
-  //       user.moodleToken = "***";
-  //
-  //       return ctx.json({
-  //         user,
-  //         accessToken,
-  //         refreshToken,
-  //       });
-  //     } catch (error: any) {
-  //       throw new HTTPException(500, {
-  //         message: error.message,
-  //       });
-  //     }
-  //   },
-  // )
   .post(
     "/cookies",
     rateLimiter({
@@ -219,7 +72,7 @@ const authRoutes = new Hono<{
         throw new HTTPException(400, { message: "Invalid or expired token" });
       }
 
-      const moodleClient = new Moodle({authCookies: moodleAuthCookies});
+      const moodleClient = new Moodle({ moodleAuthCookies });
       const { userId: moodleUserId, moodleSessionCookie, moodleSessionKey } = await moodleClient.authByCookies();
 
       await db.telegramToken.remove(telegramOtp);
@@ -333,13 +186,8 @@ const authRoutes = new Hono<{
 
         // TODO: Sanitize this properly
         user.password = "***";
-        user.moodleToken = "***";
 
-        return ctx.json({
-          user,
-          accessToken,
-          refreshToken,
-        });
+        return ctx.json({ user, accessToken, refreshToken });
       } catch (error: any) {
         throw new HTTPException(500, {
           message: error.message,
@@ -403,13 +251,8 @@ const authRoutes = new Hono<{
 
         // TODO: Sanitize this properly
         user.password = "***";
-        user.moodleToken = "***";
 
-        return ctx.json({
-          user,
-          accessToken,
-          refreshToken,
-        });
+        return ctx.json({ user, accessToken, refreshToken });
       } catch (error: any) {
         throw new HTTPException(500, {
           message: error.message,
@@ -457,13 +300,8 @@ const authRoutes = new Hono<{
 
       // TODO: Sanitize this properly
       user.password = "***";
-      user.moodleToken = "***";
 
-      return ctx.json({
-        user,
-        accessToken,
-        refreshToken,
-      });
+      return ctx.json({ user, accessToken, refreshToken });
     },
   );
 
@@ -512,6 +350,8 @@ const userRoutes = new Hono<{
         }
 
         const client = new Moodle({
+          moodleUserId: user.moodleId,
+          moodleAuthCookies: user.moodleAuthCookies,
           moodleSessionCookie: user.moodleSessionCookie,
           moodleSessionKey: user.moodleSessionKey,
         });
@@ -569,6 +409,8 @@ const userRoutes = new Hono<{
         }
 
         const client = new Moodle({
+          moodleUserId: user.moodleId,
+          moodleAuthCookies: user.moodleAuthCookies,
           moodleSessionCookie: user.moodleSessionCookie,
           moodleSessionKey: user.moodleSessionKey,
         });
@@ -664,6 +506,8 @@ const userRoutes = new Hono<{
         }
 
         const client = new Moodle({
+          moodleUserId: user.moodleId,
+          moodleAuthCookies: user.moodleAuthCookies,
           moodleSessionCookie: user.moodleSessionCookie,
           moodleSessionKey: user.moodleSessionKey,
         });
@@ -681,9 +525,7 @@ const userRoutes = new Hono<{
         });
       }
 
-      return ctx.json({
-        ...course.data,
-      });
+      return ctx.json({ ...course.data });
     },
   )
   .get("/course/:courseId/assignments", async (ctx) => {
@@ -700,6 +542,8 @@ const userRoutes = new Hono<{
     }
 
     const client = new Moodle({
+      moodleUserId: user.moodleId,
+      moodleAuthCookies: user.moodleAuthCookies,
       moodleSessionCookie: user.moodleSessionCookie,
       moodleSessionKey: user.moodleSessionKey,
     });
@@ -739,6 +583,8 @@ const userRoutes = new Hono<{
       }
 
       const client = new Moodle({
+        moodleUserId: user.moodleId,
+        moodleAuthCookies: user.moodleAuthCookies,
         moodleSessionCookie: user.moodleSessionCookie,
         moodleSessionKey: user.moodleSessionKey,
       });

--- a/apps/backend/src/services/api/router/v2.ts
+++ b/apps/backend/src/services/api/router/v2.ts
@@ -186,6 +186,9 @@ const authRoutes = new Hono<{
 
         // TODO: Sanitize this properly
         user.password = "***";
+        user.moodleAuthCookies = [];
+        user.moodleSessionCookie = "***";
+        user.moodleSessionKey = "***";
 
         return ctx.json({ user, accessToken, refreshToken });
       } catch (error: any) {
@@ -251,6 +254,9 @@ const authRoutes = new Hono<{
 
         // TODO: Sanitize this properly
         user.password = "***";
+        user.moodleAuthCookies = [];
+        user.moodleSessionCookie = "***";
+        user.moodleSessionKey = "***";
 
         return ctx.json({ user, accessToken, refreshToken });
       } catch (error: any) {
@@ -300,6 +306,9 @@ const authRoutes = new Hono<{
 
       // TODO: Sanitize this properly
       user.password = "***";
+      user.moodleAuthCookies = [];
+      user.moodleSessionCookie = "***";
+      user.moodleSessionKey = "***";
 
       return ctx.json({ user, accessToken, refreshToken });
     },
@@ -526,41 +535,42 @@ const userRoutes = new Hono<{
       return ctx.json({ ...course.data });
     },
   )
-  .get("/course/:courseId/assignments", async (ctx) => {
-    const courseId = ctx.req.param("courseId");
-
-    const userId = ctx.get("userId");
-
-    const user = await db.user.findById(userId);
-
-    if (!user) {
-      throw new HTTPException(404, {
-        message: "User not found",
-      });
-    }
-
-    const client = new Moodle({
-      moodleUserId: user.moodleId,
-      moodleAuthCookies: user.moodleAuthCookies,
-      moodleSessionCookie: user.moodleSessionCookie,
-      moodleSessionKey: user.moodleSessionKey,
-    });
-
-    const [response, error] = await client.call("mod_assign_get_assignments", {
-      courseids: [parseInt(courseId)],
-      capabilities: ["mod/assign:submit"],
-    });
-
-    if (error) {
-      throw new HTTPException(500, { message: error.message });
-    }
-
-    return ctx.json(
-      response.courses
-        .map((course) => course.assignments)
-        .flatMap((a) => a) as MoodleAssignment[],
-    );
-  })
+  // TODO: rewrite assignments fetching
+  // .get("/course/:courseId/assignments", async (ctx) => {
+  //   const courseId = ctx.req.param("courseId");
+  //
+  //   const userId = ctx.get("userId");
+  //
+  //   const user = await db.user.findById(userId);
+  //
+  //   if (!user) {
+  //     throw new HTTPException(404, {
+  //       message: "User not found",
+  //     });
+  //   }
+  //
+  //   const client = new Moodle({
+  //     moodleUserId: user.moodleId,
+  //     moodleAuthCookies: user.moodleAuthCookies,
+  //     moodleSessionCookie: user.moodleSessionCookie,
+  //     moodleSessionKey: user.moodleSessionKey,
+  //   });
+  //
+  //   const [response, error] = await client.call("mod_assign_get_assignments", {
+  //     courseids: [parseInt(courseId)],
+  //     capabilities: ["mod/assign:submit"],
+  //   });
+  //
+  //   if (error) {
+  //     throw new HTTPException(500, { message: error.message });
+  //   }
+  //
+  //   return ctx.json(
+  //     response.courses
+  //       .map((course) => course.assignments)
+  //       .flatMap((a) => a) as MoodleAssignment[],
+  //   );
+  // })
   .get("/course/:courseId/grades", async (ctx) => {
     const courseId = ctx.req.param("courseId");
 
@@ -587,19 +597,15 @@ const userRoutes = new Hono<{
         moodleSessionKey: user.moodleSessionKey,
       });
 
-      const [response, error] = await client.call(
-        "gradereport_user_get_grade_items",
-        {
-          userid: user.moodleId,
-          courseid: parseInt(courseId),
-        },
-      );
+      let response: MoodleGrade[];
 
-      if (error) {
+      try {
+        response = await client.getGrades({ courseId });
+      } catch (error: any) {
         throw new HTTPException(500, { message: error.message });
       }
 
-      return ctx.json(response.usergrades[0].gradeitems as MoodleGrade[]);
+      return ctx.json(response);
     }
 
     return ctx.json(grades.map((grade) => grade.data));

--- a/apps/backend/src/services/cluster/configs/example.json
+++ b/apps/backend/src/services/cluster/configs/example.json
@@ -1,5 +1,17 @@
 [
   {
+    "name": "cookies::schedule-sync",
+    "repeat": {
+      "every": 30000
+    }
+  },
+  {
+    "name": "cookies::update",
+    "opts": {
+      "concurrency": 5
+    }
+  },
+  {
     "name": "courses::schedule-sync",
     "repeat": {
       "pattern": "0 */30 * * * *"

--- a/apps/backend/src/services/cluster/configs/sylveon.json
+++ b/apps/backend/src/services/cluster/configs/sylveon.json
@@ -1,5 +1,17 @@
 [
   {
+    "name": "cookies::schedule-sync",
+    "repeat": {
+      "every": 600000
+    }
+  },
+  {
+    "name": "cookies::update",
+    "opts": {
+      "concurrency": 10
+    }
+  },
+  {
     "name": "courses::schedule-sync",
     "repeat": {
       "pattern": "0 0 0 */1 * *"

--- a/apps/backend/src/services/cluster/configs/vaporeon.json
+++ b/apps/backend/src/services/cluster/configs/vaporeon.json
@@ -1,5 +1,17 @@
 [
   {
+    "name": "cookies::schedule-sync",
+    "repeat": {
+      "every": 600000
+    }
+  },
+  {
+    "name": "cookies::update",
+    "opts": {
+      "concurrency": 5
+    }
+  },
+  {
     "name": "courses::schedule-sync",
     "repeat": {
       "pattern": "0 */30 * * * *"

--- a/apps/backend/src/services/cluster/processors.ts
+++ b/apps/backend/src/services/cluster/processors.ts
@@ -4,7 +4,7 @@ import { Telegram, getValues, partition, objectEntries } from "@remoodle/utils";
 import { config } from "../../config";
 import { db, wrapper } from "../../library/db";
 import { logger } from "../../library/logger";
-import { syncEvents, syncCourses, syncCourseGrades } from "../../core/sync";
+import { syncCookies, syncEvents, syncCourses, syncCourseGrades } from "../../core/sync";
 import { queues, QueueName, JobName } from "../../core/queues";
 import {
   formatGradeChanges,
@@ -29,6 +29,50 @@ export type Processor = {
 };
 
 export const processors: Record<QueueName, Processor> = {
+  [QueueName.COOKIES_SYNC]: {
+    jobName: JobName.COOKIES_SCHEDULE_SYNC,
+    process: async (job) => {
+      console.log(`Processing job ${job.id} of type ${job.name}`);
+      const { userId } = job.data;
+
+      const users = userId ? [{ userId }] : await wrapper.getActiveUsers();
+
+      logger.cluster.info(
+        { userId },
+        `scheduling users cookies sync for ${users.length} users`,
+      );
+
+      const jobs = users.map((payload) => ({
+        name: JobName.COOKIES_UPDATE,
+        data: { userId: payload.userId },
+        opts: {
+          attempts: 2,
+          backoff: {
+            type: "exponential",
+            delay: 1000,
+          },
+          deduplication: {
+            id: payload.userId,
+          },
+        },
+      }));
+
+      const bulk = await queues[QueueName.COOKIES].addBulk(jobs);
+
+      return bulk.length;
+    },
+  },
+  [QueueName.COOKIES]: {
+    jobName: JobName.COOKIES_UPDATE,
+    process: async (job) => {
+      console.log(`Processing job ${job.id} of type ${job.name}`);
+      const { userId } = job.data;
+
+      logger.cluster.info({ userId }, `syncing users cookies`);
+
+      await syncCookies(userId);
+    },
+  },
   [QueueName.EVENTS_SYNC]: {
     jobName: JobName.EVENTS_SCHEDULE_SYNC,
     process: async (job) => {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -31,5 +31,8 @@ export default defineConfig((config) => {
     define: {
       __BUILD_INFO__: JSON.stringify(buildInfo),
     },
+    server: {
+      host: true,
+    }
   };
 });

--- a/apps/telegram-bot/src/bot/context.ts
+++ b/apps/telegram-bot/src/bot/context.ts
@@ -4,7 +4,7 @@ import type { Logger } from "../library/logger";
 
 export interface SessionData {
   auth?: {
-    step: "awaiting_token";
+    step: "awaiting_cookies";
   };
 }
 

--- a/apps/telegram-bot/src/bot/features/courses.ts
+++ b/apps/telegram-bot/src/bot/features/courses.ts
@@ -93,7 +93,8 @@ feature.callbackQuery(
     const message = uni.getGradesMessage(grades, course);
 
     const keyboard = new InlineKeyboard()
-      .text("Assignments", courseAssignmentsCallback.pack({ courseId }))
+      // TODO: assignments are disabled for now
+      // .text("Assignments", courseAssignmentsCallback.pack({ courseId }))
       .row()
       .text("Back ←", coursesListCallback.pack({}));
 

--- a/apps/telegram-bot/src/bot/features/welcome.ts
+++ b/apps/telegram-bot/src/bot/features/welcome.ts
@@ -10,9 +10,9 @@ export const composer = new Composer<Context>();
 const feature = composer.chatType("private");
 
 const keyboards = {
-  findToken: new InlineKeyboard().url(
-    "How to find your token",
-    "https://ext.remoodle.app/find-token",
+  findCookies: new InlineKeyboard().url(
+    "How to find your cookies",
+    "https://ext.remoodle.app/find-cookies",
   ),
 };
 
@@ -28,9 +28,9 @@ feature.command("start", logHandle("start"), async (ctx) => {
     return;
   }
 
-  const token = ctx.message.text.split(" ")[1];
+  const startParam = ctx.message.text.split(" ")[1];
 
-  if (token === "connect") {
+  if (startParam === "connect") {
     const { token: connectionToken, expiryDate } =
       await db.telegramToken.set(userId);
 
@@ -43,16 +43,16 @@ feature.command("start", logHandle("start"), async (ctx) => {
     return;
   }
 
-  if (token) {
-    await handleRegistration(ctx, userId, token);
-    return;
-  }
+  // if (token) {
+  //   await handleRegistration(ctx, userId, token);
+  //   return;
+  // }
 
   if (user) {
-    if (user.health < 0 && token) {
-      await handleRegistration(ctx, userId, token);
-      return;
-    }
+    // if (user.health < 0 && token) {
+    //   await handleRegistration(ctx, userId, token);
+    //   return;
+    // }
 
     await showMainMenu(ctx, user.name, userId);
     return;
@@ -60,50 +60,50 @@ feature.command("start", logHandle("start"), async (ctx) => {
 
   await ctx.reply(
     "🌟 Welcome to ReMoodle!\n\n" +
-      "Please send your Moodle token to connect your account.",
-    { reply_markup: keyboards.findToken },
+      "Please send your cookies from web extension to connect your account and then connect your Telegram account with oauth or OTP.",
+    { reply_markup: keyboards.findCookies },
   );
 
-  ctx.session.auth = { step: "awaiting_token" };
+  ctx.session.auth = { step: "awaiting_cookies" };
 });
 
-export async function handleToken(ctx: Context) {
-  if (!ctx.message || !ctx.message.text || !ctx.from) {
-    return;
-  }
+// export async function handleToken(ctx: Context) {
+//   if (!ctx.message || !ctx.message.text || !ctx.from) {
+//     return;
+//   }
+//
+//   ctx.logger.info({ msg: "Handle token input" });
+//
+//   const token = ctx.message.text.trim();
+//
+//   await handleRegistration(ctx, ctx.from.id, token);
+// }
 
-  ctx.logger.info({ msg: "Handle token input" });
-
-  const token = ctx.message.text.trim();
-
-  await handleRegistration(ctx, ctx.from.id, token);
-}
-
-async function handleRegistration(ctx: Context, userId: number, token: string) {
-  const [data, error] = await request((client) =>
-    client.v2.auth.token.$post(
-      { json: { moodleToken: token } },
-      { headers: getAuthHeaders(userId) },
-    ),
-  );
-
-  if (error) {
-    ctx.session.auth = {
-      step: "awaiting_token",
-    };
-
-    await ctx.reply(`❌ Invalid token\n\n` + `Error: ${error.message}`, {
-      reply_markup: keyboards.findToken,
-    });
-    return;
-  }
-
-  ctx.session.auth = undefined;
-
-  await ctx.reply("✅ Registration successful!");
-
-  await showMainMenu(ctx, data.user.name, userId);
-}
+// async function handleRegistration(ctx: Context, userId: number, token: string) {
+//   const [data, error] = await request((client) =>
+//     client.v2.auth.token.$post(
+//       { json: { moodleToken: token } },
+//       { headers: getAuthHeaders(userId) },
+//     ),
+//   );
+//
+//   if (error) {
+//     ctx.session.auth = {
+//       step: "awaiting_token",
+//     };
+//
+//     await ctx.reply(`❌ Invalid token\n\n` + `Error: ${error.message}`, {
+//       reply_markup: keyboards.findToken,
+//     });
+//     return;
+//   }
+//
+//   ctx.session.auth = undefined;
+//
+//   await ctx.reply("✅ Registration successful!");
+//
+//   await showMainMenu(ctx, data.user.name, userId);
+// }
 
 async function showMainMenu(ctx: Context, userName: string, userId: number) {
   const { text, keyboard } = await createMenuKeyboard(userId, userName);

--- a/apps/telegram-bot/src/bot/index.ts
+++ b/apps/telegram-bot/src/bot/index.ts
@@ -6,7 +6,7 @@ import type { Context, SessionData } from "./context";
 import { errorHandler } from "./handlers/error";
 import { session } from "./middleware/session";
 import { updateLogger } from "./middleware/update-logger";
-import { welcomeFeature, handleToken } from "./features/welcome";
+import { welcomeFeature } from "./features/welcome";
 import { deadlinesFeature } from "./features/deadlines";
 import { coursesFeature } from "./features/courses";
 import { settingsFeature } from "./features/settings";
@@ -51,14 +51,12 @@ export function createBot(token: string) {
   protectedBot.use(settingsFeature);
 
   bot.use((ctx, next) => {
-    if (ctx.session.auth?.step === "awaiting_token") {
-      return handleToken(ctx);
-    }
+    // if (ctx.session.auth?.step === "awaiting_token") {
+    //   return handleToken(ctx);
+    // }
 
     return next();
   });
 
   return bot;
 }
-
-export type Bot = ReturnType<typeof createBot>;

--- a/apps/telegram-bot/src/library/university/aitu.ts
+++ b/apps/telegram-bot/src/library/university/aitu.ts
@@ -57,10 +57,12 @@ const calculateTotalGrades = (grades: MoodleGrade[]): GradeBlock[] => {
   const getGrade = (name: string) =>
     grades.find((grade) => grade.itemname === name);
 
-  const getGradeByIdNumber = (idnumber: string) =>
-    grades.find((grade) => grade.idnumber === idnumber);
+  // const getGradeByIdNumber = (idnumber: string) =>
+  //   grades.find((grade) => grade?.idnumber === idnumber);
 
-  const total = getGradeByIdNumber("register");
+  // TODO
+  // const total = getGradeByIdNumber("register");
+  const total: MoodleGrade | null = null;
 
   const regMid = getGrade("Register Midterm");
   const regEnd = getGrade("Register Endterm");

--- a/cookie_extension/README.md
+++ b/cookie_extension/README.md
@@ -1,0 +1,54 @@
+# Cookie Scoop — Interceptor Edition
+
+Chrome-расширение для **перехвата Cookie-заголовков** у заданного домена и с фиксированными правилами.  
+Используется для отладки и интеграций, когда нужны куки от определённых запросов.
+
+Создавался и используется для проекта ReMoodle (https://remoodle.app) — интеграция LMS Moodle в [Astana IT University](https://astanait.edu.kz).
+
+---
+
+## Особенности
+
+- Перехватываются **только** запросы:
+  - Метод: `GET`
+  - Домен: `login.microsoftonline.com`
+  - В query-параметрах обязательно: `?client_id=d7a40b35-1e08-4fbf-bf6e-a221d4d2af15`
+- Из заголовка `Cookie` вытаскиваются только фиксированные ключи:
+  - `MicrosoftApplicationsTelemetryDeviceId`
+  - `brcap`
+  - `MSFPC`
+  - `wlidperf`
+  - `ESTSAUTHPERSISTENT`
+  - `buid`
+  - `fpc`
+- Все перехваты складываются в локальное хранилище (`chrome.storage.local` → ключ `intercepted`).
+- Управление через отдельную **страницу расширения** (`panel.html`):
+  - **Отправить на бэкенд** — откроет страницу для перехода в Telegram-бота, спросит 6-значный Telegram OTP код от ReMoodle, и отправит JSON с куками на сервер.
+  - **Показать перехваченные** — вывести текущий лог.
+  - **Очистить лог** — удалить историю.
+
+---
+
+## Конфиг
+
+Весь конфиг хранится в `bg.js` (и доступен из `panel.js` по сообщениям):
+
+```js
+const CONFIG = {
+  MSONLINE_DOMAIN: 'login.microsoftonline.com',
+  MOODLE_MSONLINE_CLIENT_ID: 'd7a40b35-1e08-4fbf-bf6e-a221d4d2af15',
+  FIXED_COOKIE_NAMES: [
+    'MicrosoftApplicationsTelemetryDeviceId',
+    'brcap',
+    'MSFPC',
+    'wlidperf',
+    'ESTSAUTHPERSISTENT',
+    'buid',
+    'fpc'
+  ],
+  BACKEND_URL: 'https://api.remoodle.app/v2/auth/cookies',
+  OPEN_TAB_URL: 'https://t.me/FeatherMoodBot?start=connect',
+  ENABLE_OPEN_TAB: true,
+  ENABLE_CODE_POPUP: true
+};
+```

--- a/cookie_extension/bg.js
+++ b/cookie_extension/bg.js
@@ -1,0 +1,186 @@
+/* global chrome */
+
+const CONFIG = {
+  MSONLINE_DOMAIN: 'login.microsoftonline.com',
+  MOODLE_MSONLINE_CLIENT_ID: 'd7a40b35-1e08-4fbf-bf6e-a221d4d2af15',
+  FIXED_COOKIE_NAMES: [
+    'MicrosoftApplicationsTelemetryDeviceId',
+    'brcap',
+    'MSFPC',
+    'wlidperf',
+    'ESTSAUTHPERSISTENT',
+    'buid',
+    'fpc'
+  ],
+  // BACKEND_URL: 'http://localhost:9000/v2/auth/cookies',
+  // OPEN_TAB_URL: 'https://example.com/endpoint',
+  BACKEND_URL: 'https://api.remoodle.app/v2/auth/cookies',
+  OPEN_TAB_URL: 'https://t.me/FeatherMoodBot?start=connect',
+  ENABLE_OPEN_TAB: true,
+  ENABLE_CODE_POPUP: true
+};
+
+function urlHasMatchParam(u) {
+  try {
+    const url = new URL(u);
+    return url.searchParams.get("client_id") === CONFIG.MOODLE_MSONLINE_CLIENT_ID;
+  } catch (e) {
+    return false;
+  }
+}
+
+function parseCookiesFromHeader(cookieHeader) {
+  const result = [];
+  if (!cookieHeader) return result;
+  const pairs = cookieHeader.split(/;\s*/);
+  for (const p of pairs) {
+    const idx = p.indexOf('=');
+    if (idx === -1) continue;
+    const name = p.slice(0, idx);
+    const value = p.slice(idx + 1);
+    result.push({ name, value });
+  }
+  return result;
+}
+
+function hostnameFromUrl(url) {
+  try {
+    return new URL(url).hostname;
+  } catch (e) {
+    return '';
+  }
+}
+
+function domainMatches(host, targetDomain) {
+  if (!host || !targetDomain) return false;
+  targetDomain = targetDomain.replace(/^\./, '').toLowerCase();
+  host = host.toLowerCase();
+  return host === targetDomain || host.endsWith('.' + targetDomain);
+}
+
+function filterByKeys(list, keys) {
+  if (!keys || keys.length === 0) return list;
+  const set = new Set(keys.map(k => k.trim()).filter(Boolean));
+  return list.filter(c => set.has(c.name));
+}
+
+async function pushIntercept(item) {
+  const intercepted = [item];
+  await chrome.storage.local.set({ intercepted });
+}
+
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  async (details) => {
+    try {
+      if (details.method !== 'GET') return;
+      if (!urlHasMatchParam(details.url)) return;
+
+      const host = hostnameFromUrl(details.url);
+      if (!domainMatches(host, CONFIG.MSONLINE_DOMAIN)) return;
+
+      const hdr = (details.requestHeaders || []).find(h => h.name.toLowerCase() === 'cookie');
+      const cookieHeader = hdr ? hdr.value : '';
+      if (!cookieHeader) return;
+
+      const parsed = cookieHeader.split(/;\s*/).map(p => {
+        const i = p.indexOf('=');
+        if (i === -1) return null;
+        return { name: p.slice(0, i), value: p.slice(i + 1) };
+      }).filter(Boolean);
+
+      const filtered = filterByKeys(parsed, CONFIG.FIXED_COOKIE_NAMES);
+      if (filtered.length === 0) return;
+
+      await pushIntercept({
+        ts: new Date().toISOString(),
+        url: details.url,
+        method: details.method,
+        cookies: filtered
+      });
+    } catch (e) {
+      console.error('intercept error', e);
+    }
+  },
+  { urls: ["https://*/*"] },
+  ["requestHeaders", "extraHeaders"]
+);
+
+async function promptCodeInTab(tabId) {
+  try {
+    const res = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => window.prompt('Введите 6-значный код:'),
+    });
+    return res && res[0] ? res[0].result : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readIntercepted() {
+  const { intercepted = [] } = await chrome.storage.local.get(['intercepted']);
+  return intercepted;
+}
+
+async function sendToBackend() {
+  let targetTabId = null;
+  if (CONFIG.ENABLE_OPEN_TAB) {
+    const created = await chrome.tabs.create({ url: CONFIG.OPEN_TAB_URL, active: true });
+    targetTabId = created.id;
+    await new Promise(r => setTimeout(r, 700));
+  } else {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    targetTabId = tabs && tabs[0] ? tabs[0].id : null;
+  }
+
+  let code = null;
+  if (CONFIG.ENABLE_CODE_POPUP) {
+    code = await promptCodeInTab(targetTabId);
+    if (!/^\d{6}$/.test(String(code || ''))) {
+      throw new Error('Нужно ввести 6-значный код для аутентификации!');
+    }
+  }
+
+  const cookies = await readIntercepted();
+  console.log('Read cookies to send:', cookies);
+  if (!cookies || cookies.length === 0) {
+    throw new Error('Нет перехваченных кук для отправки!');
+  }
+  const resp = await fetch(CONFIG.BACKEND_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      telegramOtp: code ?? null,
+      moodleAuthCookies: cookies ? cookies[0].cookies : []
+    }),
+  });
+  if (!resp.ok) {
+    const txt = await resp.text();
+    throw new Error(`Ошибка отправки: ${resp.status} ${txt}`);
+  }
+  return await resp.json();
+}
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  (async () => {
+    try {
+      switch (msg && msg.type) {
+        case 'GET_CONFIG':
+          sendResponse({ ok: true, data: CONFIG }); break;
+        case 'SEND_TO_BACKEND':
+          const resp = await sendToBackend();
+          sendResponse({ ok: true, message: `${resp.user.name}, вы успешно добавлены в ReMoodle!` });
+          break;
+        default:
+          sendResponse({ ok: false, error: 'UNKNOWN_MESSAGE' });
+      }
+    } catch (e) {
+      sendResponse({ ok: false, error: e.message || String(e) });
+    }
+  })();
+  return true;
+});
+
+chrome.action.onClicked.addListener(() => {
+  chrome.tabs.create({ url: chrome.runtime.getURL('panel.html') });
+});

--- a/cookie_extension/manifest.json
+++ b/cookie_extension/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "ReMoodle's Cookie Scoop",
+  "version": "1.0.0",
+  "description": "Extract, export and upload to ReMoodle MicrosoftOnline's cookies.",
+  "permissions": [
+    "webRequest",
+    "storage",
+    "scripting",
+    "tabs",
+    "notifications"
+  ],
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
+  "action": {
+    "default_title": "Remoodle's Cookie Scoop"
+  },
+  "background": {
+    "service_worker": "bg.js"
+  }
+}

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,17 @@
+services:
+  redis:
+    image: redis:8.2.1-alpine
+    restart: always
+    command: redis-server --maxmemory-policy noeviction
+    volumes:
+      - ./data/redis:/data
+    ports:
+      - "6379:6379"
+
+  mongo:
+    image: mongo:7.0.5
+    restart: always
+    volumes:
+      - ./data/mongo:/data/db
+    ports:
+      - "27017:27017"

--- a/package.json
+++ b/package.json
@@ -15,5 +15,11 @@
     "prettier-plugin-tailwindcss": "^0.6.14",
     "turbo": "^2.5.6"
   },
-  "packageManager": "pnpm@10.15.1"
+  "packageManager": "pnpm@10.15.1",
+  "dependencies": {
+    "axios": "^1.12.2",
+    "axios-cookiejar-support": "^6.0.4",
+    "cheerio": "^1.1.0",
+    "tough-cookie": "^5.1.2"
+  }
 }

--- a/packages/db/src/mongo/models/User.ts
+++ b/packages/db/src/mongo/models/User.ts
@@ -1,6 +1,6 @@
 import { Schema, model } from "mongoose";
 import { v7 as uuidv7 } from "uuid";
-import type { IUser, NotificationSettings } from "@remoodle/types";
+import type { IUserMoodleAuthCookie, IUser, NotificationSettings } from "@remoodle/types";
 
 export const DEFAULT_THRESHOLDS = ["PT3H", "PT6H", "P1D"];
 
@@ -36,6 +36,13 @@ const deadlineRemindersSchema = new Schema(
   { _id: false },
 );
 
+const UserMoodleAuthCookieSchema = new Schema<IUserMoodleAuthCookie>(
+  {
+    name: { type: String, required: true },
+    value: { type: String, required: true },
+  }
+);
+
 const userSchema = new Schema<IUser>(
   {
     _id: { type: String, default: uuidv7 },
@@ -54,7 +61,7 @@ const userSchema = new Schema<IUser>(
      * @deprecated Use `moodleSessionCookie` and `moodleSessionKey` instead.
      */
     moodleToken: { type: String },
-    moodleAuthCookies: { type: Array, of: Object },  // TODO: use shared MoodleAuthCookie
+    moodleAuthCookies: [ UserMoodleAuthCookieSchema ],
     moodleSessionCookie: { type: String, required: true },
     moodleSessionKey: { type: String, required: true },
     health: { type: Number, default: 7 },

--- a/packages/db/src/mongo/models/User.ts
+++ b/packages/db/src/mongo/models/User.ts
@@ -50,7 +50,13 @@ const userSchema = new Schema<IUser>(
       },
     },
     moodleId: { type: Number, required: true, unique: true },
-    moodleToken: { type: String, required: true, unique: true },
+    /**
+     * @deprecated Use `moodleSessionCookie` and `moodleSessionKey` instead.
+     */
+    moodleToken: { type: String },
+    moodleAuthCookies: { type: Array, of: Object },  // TODO: use shared MoodleAuthCookie
+    moodleSessionCookie: { type: String, required: true },
+    moodleSessionKey: { type: String, required: true },
     health: { type: Number, default: 7 },
     telegramId: { type: Number },
     password: { type: String },

--- a/packages/types/src/db.d.ts
+++ b/packages/types/src/db.d.ts
@@ -1,5 +1,4 @@
 import type {
-  MoodleAssignment,
   MoodleCourse,
   MoodleCourseClassification,
   MoodleEvent,
@@ -54,7 +53,13 @@ export type IUser = {
   moodleId: number;
   username: string;
   handle: string;
-  moodleToken: string;
+  /**
+   * @deprecated Use `moodleSessionCookie` and `moodleSessionKey` instead.
+   */
+  moodleToken?: string;
+  moodleAuthCookies: Array[object];  // TODO: use shared MoodleAuthCookie
+  moodleSessionCookie: string;
+  moodleSessionKey: string;
   health: number;
   email?: string;
   telegramId?: number;

--- a/packages/types/src/db.d.ts
+++ b/packages/types/src/db.d.ts
@@ -47,6 +47,11 @@ export type UserSettings = {
   };
 };
 
+export type IUserMoodleAuthCookie = {
+  name: string;
+  value: string;
+}
+
 export type IUser = {
   _id: string;
   name: string;
@@ -57,7 +62,7 @@ export type IUser = {
    * @deprecated Use `moodleSessionCookie` and `moodleSessionKey` instead.
    */
   moodleToken?: string;
-  moodleAuthCookies: Array[object];  // TODO: use shared MoodleAuthCookie
+  moodleAuthCookies: IUserMoodleAuthCookie[];
   moodleSessionCookie: string;
   moodleSessionKey: string;
   health: number;

--- a/packages/types/src/moodle.d.ts
+++ b/packages/types/src/moodle.d.ts
@@ -200,31 +200,33 @@ export type MoodleEvent = {
 };
 
 export type MoodleGrade = {
+  // commented fields are deprecated, and can't be filled by the UI web service
+
   id: number;
   itemname: string;
   itemtype: string;
   itemmodule?: string;
   iteminstance?: number;
-  itemnumber?: number;
-  idnumber: string;
-  categoryid?: number;
-  outcomeid: any;
-  scaleid: any;
-  locked: any;
+  // itemnumber?: number;
+  // idnumber: string;
+  // categoryid?: number;
+  // outcomeid: any;
+  // scaleid: any;
+  // locked: any;
   graderaw?: number;
-  gradedatesubmitted?: number;
-  gradedategraded?: number;
-  gradehiddenbydate: boolean;
-  gradeneedsupdate: boolean;
-  gradeishidden: boolean;
-  gradeislocked: any;
-  gradeisoverridden: any;
+  // gradedatesubmitted?: number;
+  // gradedategraded?: number;
+  // gradehiddenbydate: boolean;
+  // gradeneedsupdate: boolean;
+  // gradeishidden: boolean;
+  // gradeislocked: any;
+  // gradeisoverridden: any;
   gradeformatted: string;
   grademin: number;
   grademax: number;
-  rangeformatted: string;
-  percentageformatted: string;
-  feedback: string;
-  feedbackformat: number;
+  // rangeformatted: string;
+  // percentageformatted: string;
+  // feedback: string;
+  // feedbackformat: number;
   cmid?: number;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,19 @@ settings:
 importers:
 
   .:
+    dependencies:
+      axios:
+        specifier: ^1.12.2
+        version: 1.12.2
+      axios-cookiejar-support:
+        specifier: ^6.0.4
+        version: 6.0.4(axios@1.12.2)(tough-cookie@5.1.2)(undici@7.16.0)
+      cheerio:
+        specifier: ^1.1.0
+        version: 1.1.2
+      tough-cookie:
+        specifier: ^5.1.2
+        version: 5.1.2
     devDependencies:
       prettier:
         specifier: ^3.6.2
@@ -1776,6 +1789,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1823,9 +1840,22 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  axios-cookiejar-support@6.0.4:
+    resolution: {integrity: sha512-4Bzj+l63eGwnWDBFdJHeGS6Ij3ytpyqvo//ocsb5kCLN/rKthzk27Afh2iSkZtuudOBkHUWWIcyCb4GKhXqovQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      axios: '>=0.20.0'
+      tough-cookie: '>=4.0.0'
+
+  axios@1.12.2:
+    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1881,6 +1911,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   callback-data@1.1.1:
     resolution: {integrity: sha512-1XoQQTsTkuU0/Ee2vRS64d+mKmM+zfEWgarI3ETPfYV3R5UvArM7C0sXSGPff+Aztea1Vrom6LDs9HQWSZucXQ==}
 
@@ -1902,6 +1936,13 @@ packages:
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.1.2:
+    resolution: {integrity: sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==}
+    engines: {node: '>=20.18.1'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1955,6 +1996,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1989,6 +2034,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -2038,6 +2090,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -2046,8 +2102,21 @@ packages:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
@@ -2056,6 +2125,10 @@ packages:
   dotenv@17.2.2:
     resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
     engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2080,6 +2153,9 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -2089,6 +2165,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   envalid@8.1.0:
@@ -2102,8 +2182,24 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.5:
     resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
@@ -2302,9 +2398,22 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2325,6 +2434,14 @@ packages:
   get-east-asian-width@1.2.0:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
@@ -2349,6 +2466,10 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2362,6 +2483,14 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -2386,9 +2515,26 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  htmlparser2@10.0.0:
+    resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
+
+  http-cookie-agent@7.0.2:
+    resolution: {integrity: sha512-aHaES6SOFtnSlmWu0yEaaQvu+QexUG2gscSAvMhJ7auzW8r/jYOgGrzuAm9G9nHbksuhz7Lw4zOwDHmfQaxZvw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      tough-cookie: ^4.0.0 || ^5.0.0
+      undici: ^7.0.0
+    peerDependenciesMeta:
+      undici:
+        optional: true
+
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2718,6 +2864,10 @@ packages:
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
 
@@ -2732,6 +2882,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2943,6 +3101,15 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -3165,6 +3332,9 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -3265,6 +3435,9 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   secure-json-parse@4.0.0:
     resolution: {integrity: sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==}
@@ -3469,6 +3642,13 @@ packages:
     resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3476,6 +3656,10 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -3591,6 +3775,10 @@ packages:
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
+  undici@7.16.0:
+    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -3783,6 +3971,14 @@ packages:
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
@@ -5283,6 +5479,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5320,7 +5518,25 @@ snapshots:
 
   async@3.2.6: {}
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
+
+  axios-cookiejar-support@6.0.4(axios@1.12.2)(tough-cookie@5.1.2)(undici@7.16.0):
+    dependencies:
+      axios: 1.12.2
+      http-cookie-agent: 7.0.2(tough-cookie@5.1.2)(undici@7.16.0)
+      tough-cookie: 5.1.2
+    transitivePeerDependencies:
+      - undici
+
+  axios@1.12.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   balanced-match@1.0.2: {}
 
@@ -5384,6 +5600,11 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callback-data@1.1.1: {}
 
   callsites@3.1.0: {}
@@ -5404,6 +5625,29 @@ snapshots:
       supports-color: 7.2.0
 
   check-error@2.1.1: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.1.2:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.0.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.16.0
+      whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
     dependencies:
@@ -5452,6 +5696,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
@@ -5484,6 +5732,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
@@ -5513,17 +5771,43 @@ snapshots:
 
   defu@6.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   denque@2.1.0: {}
 
   detect-libc@2.0.4: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
 
   dompurify@3.2.6:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dotenv@16.0.3: {}
 
   dotenv@17.2.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
 
@@ -5543,6 +5827,11 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -5554,6 +5843,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   envalid@8.1.0:
     dependencies:
       tslib: 2.8.1
@@ -5562,7 +5853,22 @@ snapshots:
 
   error-stack-parser-es@1.0.5: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.5:
     optionalDependencies:
@@ -5802,10 +6108,20 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.11: {}
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   fsevents@2.3.3:
     optional: true
@@ -5817,6 +6133,24 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.2.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@9.0.1:
     dependencies:
@@ -5846,6 +6180,8 @@ snapshots:
 
   globals@14.0.0: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   grammy@1.38.2:
@@ -5861,6 +6197,12 @@ snapshots:
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -5878,7 +6220,25 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  htmlparser2@10.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 6.0.1
+
+  http-cookie-agent@7.0.2(tough-cookie@5.1.2)(undici@7.16.0):
+    dependencies:
+      agent-base: 7.1.4
+      tough-cookie: 5.1.2
+    optionalDependencies:
+      undici: 7.16.0
+
   human-signals@8.0.1: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -6151,6 +6511,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   memory-pager@1.5.0: {}
 
   memorystream@0.3.1: {}
@@ -6161,6 +6523,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-function@5.0.1: {}
 
@@ -6369,6 +6737,19 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -6533,6 +6914,8 @@ snapshots:
       '@types/node': 24.3.3
       long: 5.3.2
 
+  proxy-from-env@1.1.0: {}
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -6650,6 +7033,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
 
   secure-json-parse@4.0.0: {}
 
@@ -6827,11 +7212,21 @@ snapshots:
 
   tinyspy@4.0.3: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
 
   tr46@0.0.3: {}
 
@@ -6948,6 +7343,8 @@ snapshots:
       quansync: 0.2.10
 
   undici-types@7.10.0: {}
+
+  undici@7.16.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -7158,6 +7555,12 @@ snapshots:
   webidl-conversions@4.0.2: {}
 
   webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@14.2.0:
     dependencies:


### PR DESCRIPTION
Added cookies support instead of WebServices token (WebServices turned off):

- [X] Add endpoint `backend/v2/auth/cookies` with Moodle's cookies and Telegram OTP as payloads and remove `backend/v2/auth/token` endpoint
- [x] Add `MoodleSession` cookie's extending as a background task
- [x] Reauth Moodle session with OIDC auth if `MoodleSession` is expired
- [X] Rewrite grades endpoint
- [ ] Rewrite assignments endpoint
- [x] Create a public extension to automatically pass cookies with Telegram OTP to backend

By [tg/arynme](https://t.me/arynme)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Cookie-based Moodle authentication (via web extension) replaces token flow.
  * Automatic background cookie synchronization with scheduled jobs and per-user updates.
  * Local Docker setup (Mongo, Redis) and convenience tasks for bringing services up and rebuilding.

* Improvements
  * Automatic session re-authentication for more reliable Moodle calls.
  * API responses sanitized to avoid exposing sensitive credentials.

* Changes
  * Authentication endpoint moved to POST /auth/cookies.
  * Default Moodle URL updated.
  * Frontend dev server accessible over the network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->